### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://firdousahmad.visualstudio.com/39cebe34-1788-4da1-b379-ba68c98a444c/b7bac0a6-7913-4b29-89ee-7d6e9836c813/_apis/work/boardbadge/238fefc7-975e-4386-b8ae-97511d41413b)](https://firdousahmad.visualstudio.com/39cebe34-1788-4da1-b379-ba68c98a444c/_boards/board/t/b7bac0a6-7913-4b29-89ee-7d6e9836c813/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://firdousahmad.visualstudio.com/39cebe34-1788-4da1-b379-ba68c98a444c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.